### PR TITLE
FDN-3571: do not run_maintenance in install.sh

### DIFF
--- a/install.sh
+++ b/install.sh
@@ -19,7 +19,6 @@ then
 	psql -q -U postgres -d postgres -c "GRANT ALL ON DATABASE $DBNAME TO api"
 	psql -q -U postgres -d $DBNAME -f $DBNAME.schema.sql
 	psql -q -U postgres -d $DBNAME -f $DBNAME.data.sql
-	psql -q -U api -d $DBNAME -c 'SELECT partman5.run_maintenance()'
 fi
 
 sem-apply --url postgresql://api@localhost/$DBNAME


### PR DESCRIPTION
The step is time consuming, memory consuming, more so as time goes by.
Eventually it will hit limits (e.g., number of locks acquired) and fail.
It happened in some repository already, and this step has been removed there as a consequence.
It is also an unnecessary step, so we remove it.
